### PR TITLE
Debugging missing parentElement issue

### DIFF
--- a/client/src/gameSection/Context/GameContext.jsx
+++ b/client/src/gameSection/Context/GameContext.jsx
@@ -7,7 +7,7 @@ export const GameContext = createContext(null);
 function GameContextProvider({ children }) {
   const [currentTaskIndex, setCurrentTaskIndex] = useState(0);
   const [currentTask, setCurrentTask] = useState(null);
-  const [showSnippet, setShowSnippet] = useState(false);
+  // const [showSnippet, setShowSnippet] = useState(false);
   const [data, setData] = useState(null);
   const [blanks, setBlanks] = useState('');
   const [exerciseGenerated, setExerciseGenerated] = useState(false);
@@ -25,6 +25,14 @@ function GameContextProvider({ children }) {
   const [opacity, setOpacity] = useState(0);
   const [timerVisible, setTimerVisible] = useState(false);
   const [countdownVisible, setCountdownVisible] = useState(false);
+
+  const [showSnippet, setTheShowSnippet] = useState(false);
+
+  const setShowSnippet = (value, render) => {
+    console.log("setShowSnippet:", value, render);
+    
+    setTheShowSnippet(value)
+  }
 
   const timer = () => {
     let duration;

--- a/client/src/gameSection/Logic/functions.js
+++ b/client/src/gameSection/Logic/functions.js
@@ -1,7 +1,9 @@
 /* eslint-disable */
 
 // function to add input fields to the code snippets
-export function generateExercise(text, numBlanks) {
+export function generateExercise(text, numBlanks, showSnippet, render) {
+  console.log("generate showSnippet:", showSnippet, render);
+  
   const parentElement = document.querySelector('.language-javascript');
   const spanElements = parentElement.querySelectorAll('span:not(:empty)');
   const selectedSpanIndices = [];

--- a/client/src/gameSection/TaskSection/TaskSection.jsx
+++ b/client/src/gameSection/TaskSection/TaskSection.jsx
@@ -10,13 +10,17 @@ import { GameContext } from '../Context/GameContext.jsx';
 import LevelSelector from 'gameSection/LevelSelector/LevelSelector.jsx';
 import './TaskSection.css';
 
+let render = 0
+
 const TaskSection = () => {
+  
+  let gameContext = useContext(GameContext);
+  let { showSnippet } = gameContext
   const {
     currentTaskIndex,
     setCurrentTaskIndex,
     currentTask,
     setCurrentTask,
-    showSnippet,
     setShowSnippet,
     data,
     setBlanks,
@@ -36,14 +40,25 @@ const TaskSection = () => {
     setTimerVisible,
     countdownVisible,
     setCountdownVisible
-  } = useContext(GameContext);
+  } = gameContext;
+
+  console.log("render:", ++render, ", showSnippet:", showSnippet );
+
 
   const handleAcceptClick = () => {
     setTaskAccepted(true);
-    setShowSnippet(true);
+    showSnippet = true;
+    setShowSnippet(showSnippet, render);
+    console.log("accept showSnippet:", showSnippet, render);
+    
     setCountdownVisible(true);
     setTimeout(() => {
-      const codeWithBlanks = generateExercise(formattedCode, numBlanks);
+      console.log("timeout showSnippet:", showSnippet, render);
+      
+      if (!showSnippet) {
+        return
+      }
+      const codeWithBlanks = generateExercise(formattedCode, numBlanks, showSnippet, render);
       timer(); //function from GameContext
       setBlanks(codeWithBlanks); //task with input fields is displayed
       setCountdownVisible(false);
@@ -59,11 +74,18 @@ const TaskSection = () => {
     setCurrentTask(data[selectedLevel][nextIndex][`task${nextIndex + 1}`]);
     setExerciseGenerated(false); //task with input field no longer visible
     setBlanks(''); //reset the input field to 0
-    setShowSnippet(false); //task snippet no longer visible
+    showSnippet = false
+    setShowSnippet(showSnippet, render); //task snippet no longer visible
+
+    console.log("next showSnippet:", showSnippet, render);
+
     setTaskAccepted(false); //accept btn is visible
     resetTimer(); //timer is set to 0
     setTimerVisible(false);
     setOpacity(0); //timer-end message no longer visible
+
+    
+    setCountdownVisible(false);
   };
 
   const handlePreviousClick = () => {


### PR DESCRIPTION
Changes to show that the timeout function is called with out-of-date values. Check in the Console how the value of `showSnippet` is set to `false` when the Next button is pressed, but the call to generateExercise is still called because the closure it is in retains a value of `true` for showSnippet.

Logic/functions.js
===
* Add value of showSnippet and render to call to generateExercise
* Log these values after generateExercise is called

TaskSection.jsx
===
* Use `let` for showSnippet, so that its value can be changed
* Log render index and showSnippet value on each function call
* Change value of showSnippet locally before calling setShowSnippet

handleAcceptClick
---
* Check if showSnippet is true in timeout, before calling generateExercise

handleNextClick
---
* Set showSnippet to false locally, and log it
* Call setCountDownVisible(false)

GameContext.jsx
===
* Replace React's setShowSnippet with a custom function
* Use setTHEShowSnippet for the React useState
* Log the value and the render index when setShowSnippet is called